### PR TITLE
Possible solution to issue #2

### DIFF
--- a/lib/Sub/Called.pm
+++ b/lib/Sub/Called.pm
@@ -115,9 +115,13 @@ sub with_ampersand {
                    }
                }
            }
-           else {
+           elsif ('GV' eq ( my $class = B::class( $op->gv )) ) {
               $globname = $op->gv->NAME;
               $stash    = $op->gv->STASH->NAME; 
+           }
+	   else {
+	      next if $class eq "IV";
+	      die "$name -> $class";
            }
 
            my $check = $stash . '::' . $globname;


### PR DESCRIPTION
It looks like the op tree is diferent on theaded perls where test 05 is
ok and non threaded ones where it fails when the gv method of an SVOP
returns an IV object in plade of a GV.

The soluton pases form checkin that the response is realy a GV and
in case this is not true whe pass to the next op or die if is not an IV